### PR TITLE
Move test to the drop-in project only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - SCALAJS_VERSION=""
 
 script:
-  - sbt fullOptJS
+  - sbt "test;fullOptJS"
 
 before_cache:
   - rm -fv $HOME/.ivy2/.sbt.ivy.lock

--- a/build.sbt
+++ b/build.sbt
@@ -30,10 +30,6 @@ def BaseProject(name: String): Project =
           </developer>
         </developers>,
       pomIncludeRepository := { _ => false },
-      libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6",
-      libraryDependencies += "com.lihaoyi" %%% "utest" % "0.7.4" % "test",
-      jsDependencies += ("org.webjars.npm" % "js-joda" % "1.6.2" / "dist/js-joda.js" minified "dist/js-joda.min.js") % "test",
-      jsDependencies += (ProvidedJS / "test.js" dependsOn "dist/js-joda.js") % "test",
       testFrameworks += new TestFramework("utest.runner.Framework")
     )
     .enablePlugins(ScalaJSPlugin)
@@ -57,7 +53,11 @@ lazy val javaTime =
       mappings in(Compile, packageBin) ~= {
         _.filter(!_._2.endsWith(".class"))
       },
-      exportJars := true
+      exportJars := true,
+      libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6",
+      libraryDependencies += "com.lihaoyi" %%% "utest" % "0.7.4" % "test",
+      jsDependencies += ("org.webjars.npm" % "js-joda" % "1.6.2" / "dist/js-joda.js" minified "dist/js-joda.min.js") % "test",
+      jsDependencies += (ProvidedJS / "test.js" dependsOn "dist/js-joda.js") % "test",
     )
     .dependsOn(facade)
 

--- a/java-time-drop-in/src/main/resources/test.js
+++ b/java-time-drop-in/src/main/resources/test.js
@@ -1,1 +1,0 @@
-var JSJoda = module.exports;

--- a/java-time-drop-in/src/test/resources/test.js
+++ b/java-time-drop-in/src/test/resources/test.js
@@ -1,0 +1,1 @@
+var JSJoda = module.exports;


### PR DESCRIPTION
This fixes running `test ` for root project.